### PR TITLE
Make PR title and body customizable templates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,14 @@ inputs:
   github_token:
     description: Token for the GitHub API.
     required: true
+  pr_title:
+    description: The title template to give the automatically created backport PRs. Supported template variables are: 'pr_branch', 'pr_number', and 'base_branch'
+    required: false
+    default: 'chore: backport #{pr_number} into {pr_branch}'
+  pr_body:
+    description: The body template to give the automatically created backport PRs. Supported template variables are: 'pr_branch', 'pr_number', and 'base_branch'
+    required: false
+    default: 'An automated backport for #{pr_number}.'
 branding:
   icon: chevron-left
   color: gray-dark
@@ -16,4 +24,6 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.pr_branch }}
+    - ${{ inputs.pr_title }}
+    - ${{ inputs.pr_body }}
     - ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,11 @@ inputs:
     description: Token for the GitHub API.
     required: true
   pr_title:
-    description: The title template to give the automatically created backport PRs. Supported template variables are: 'pr_branch', 'pr_number', and 'base_branch'
+    description: 'The title template to give the automatically created backport PRs. Supported template variables are: pr_branch, pr_number, and base_branch'
     required: false
     default: 'chore: backport #{pr_number} into {pr_branch}'
   pr_body:
-    description: The body template to give the automatically created backport PRs. Supported template variables are: 'pr_branch', 'pr_number', and 'base_branch'
+    description: 'The body template to give the automatically created backport PRs. Supported template variables are: pr_branch, pr_number, and base_branch'
     required: false
     default: 'An automated backport for #{pr_number}.'
 branding:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python /action/main.py $*
+python /action/main.py "$@"


### PR DESCRIPTION
Supported template variables are: 'pr_branch', 'pr_number', and 'base_branch'. The default title and body will stay the same. I'm making this PR because I'm not a fan of the default title and this was low hanging fruit. :) Thanks for the cool action!

An unrelated issue: how hard would it be to use the squashed commit instead of the individual commits?